### PR TITLE
Rotation check fixed in LaserScanMatcher::newKeyframeNeeded

### DIFF
--- a/laser_scan_matcher/src/laser_scan_matcher.cpp
+++ b/laser_scan_matcher/src/laser_scan_matcher.cpp
@@ -497,7 +497,7 @@ void LaserScanMatcher::processScan(LDP& curr_ldp_scan, const ros::Time& time)
 
 bool LaserScanMatcher::newKeyframeNeeded(const tf::Transform& d)
 {
-  if (tf::getYaw(d.getRotation()) > kf_dist_angular_) return true;
+  if (fabs(tf::getYaw(d.getRotation())) > kf_dist_angular_) return true;
 
   double x = d.getOrigin().getX();
   double y = d.getOrigin().getY();


### PR DESCRIPTION
It seems that only left turns triggered an update...
