### PR TITLE
csm: Add cpp export flags to manifest.xml

### DIFF
--- a/csm/manifest.xml
+++ b/csm/manifest.xml
@@ -12,6 +12,10 @@
   <url>http://ros.org/wiki/csm</url>
   <rosdep name="libgsl"/>
 
+  <export>
+    <cpp cflags="-I${prefix}/include" lflags="-L${prefix}/lib -Wl,-rpath,${prefix}/lib -lcsm"/>
+  </export>
+
 </package>
 
 


### PR DESCRIPTION
Exporting the cflags and lflags in manifest.xml for the headers and library so that it's easy for other packages to use the library.
