### PR TITLE
Update pcl depends

### DIFF
--- a/laser_ortho_projector/package.xml
+++ b/laser_ortho_projector/package.xml
@@ -18,21 +18,23 @@
   <build_depend>nodelet</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>tf</build_depend>
-  <build_depend>pcl</build_depend>
   <build_depend>pcl_ros</build_depend>
   <build_depend>pcl_conversions</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>message_filters</build_depend>
 
+  <build_depend>libpcl-all-dev</build_depend>
+
   <run_depend>roscpp</run_depend>
   <run_depend>nodelet</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>tf</run_depend>
-  <run_depend>pcl</run_depend>
   <run_depend>pcl_ros</run_depend>
   <run_depend>pcl_conversions</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>message_filters</run_depend>
+
+  <run_depend>libpcl-all</run_depend>
 
   <export>
     <nodelet plugin="${prefix}/laser_ortho_projector_nodelet.xml" />

--- a/laser_scan_matcher/package.xml
+++ b/laser_scan_matcher/package.xml
@@ -23,22 +23,24 @@
   <build_depend>nodelet</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>tf</build_depend>
-  <build_depend>pcl</build_depend>
   <build_depend>pcl_ros</build_depend>
   <build_depend>pcl_conversions</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>nav_msgs</build_depend>
+
+  <build_depend>libpcl-all-dev</build_depend>
   <build_depend>libgsl</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>nodelet</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>tf</run_depend>
-  <run_depend>pcl</run_depend>
   <run_depend>pcl_ros</run_depend>
   <run_depend>pcl_conversions</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>nav_msgs</run_depend>
+
+  <run_depend>libpcl-all</run_depend>
   <run_depend>libgsl</run_depend>
 
   <export>

--- a/scan_to_cloud_converter/package.xml
+++ b/scan_to_cloud_converter/package.xml
@@ -15,13 +15,15 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>roscpp</build_depend>
-  <build_depend>pcl</build_depend>
   <build_depend>pcl_ros</build_depend>
   <build_depend>pcl_conversions</build_depend>
 
+  <build_depend>libpcl-all-dev</build_depend>
+
   <run_depend>roscpp</run_depend>
-  <run_depend>pcl</run_depend>
   <run_depend>pcl_ros</run_depend>
   <run_depend>pcl_conversions</run_depend>
+
+  <run_depend>libpcl-all</run_depend>
 
 </package>


### PR DESCRIPTION
This fixes the following error when running `rosdep install --from-paths src -iy` from the workspace with `scan_tools`:

```
ERROR: the following packages/stacks could not have their rosdep keys resolved
to system dependencies:
scan_to_cloud_converter: Cannot locate rosdep definition for [pcl]
laser_ortho_projector: Cannot locate rosdep definition for [pcl]
laser_scan_matcher: Cannot locate rosdep definition for [pcl]
```
