### PR TITLE
[laser_scan_matcher] Update CSM commit to today's latest

### DIFF
--- a/laser_scan_matcher/csm/GetCSM.cmake
+++ b/laser_scan_matcher/csm/GetCSM.cmake
@@ -17,7 +17,7 @@ function( download_and_compile_csm )
         SOURCE_DIR ${CSM_BINARY_DIR}/src
         #--Download step -----------------------------------------------------------
         GIT_REPOSITORY https://github.com/AndreaCensi/csm.git
-        GIT_TAG 23703a998fff57250322
+        GIT_TAG 56919d39f69d1d91c4a909750ff8516c42b3f0e9
         #-- Update/Patch command ---------------------------------------------------
         PATCH_COMMAND patch -p0 -d ${CSM_BINARY_DIR}/src < ${CSM_PATCH_DIR}/patch_a && patch -p0 -d ${CSM_BINARY_DIR}/src < ${CSM_PATCH_DIR}/patch_b && patch -p0 -d ${CSM_BINARY_DIR}/src < ${CSM_PATCH_DIR}/patch_c && patch -p0 -d ${CSM_BINARY_DIR}/src < ${CSM_PATCH_DIR}/patch_d
         #-- Configure step ---------------------------------------------------------

--- a/laser_scan_matcher/package.xml
+++ b/laser_scan_matcher/package.xml
@@ -3,11 +3,12 @@
   <version>0.2.1</version>
   <description>
     <p>
-     An incremental laser scan matcher, using Andrea Censi's Canonical Scan Matcher implementation. Package downloads and installs Canonical Scan Matcher locally.  Patches are applied to accept scans in cartesian (x,y) coordinates. More about <a href="http://www.cds.caltech.edu/~andrea/research/sw/csm.html">CSM</a>. NOTE the Canonical Scan Matcher library is licensed under the GNU Lesser General Public License v3, whereas the rest of the code is released under the BSD license.
+     An incremental laser scan matcher, using Andrea Censi's Canonical Scan Matcher implementation. Package downloads and installs Canonical Scan Matcher locally.  Patches are applied to accept scans in cartesian (x,y) coordinates. More about <a href="http://censi.mit.edu/software/csm/">CSM</a>. NOTE the Canonical Scan Matcher library is licensed under the GNU Lesser General Public License v3, whereas the rest of the code is released under the BSD license.
     </p>
   </description>
   <maintainer email="ccnyroboticslab@gmail.com">Ivan Dryanovski</maintainer>
   <maintainer email="cjaramillo@gc.cuny.edu">Carlos</maintainer>
+  <maintainer email="iiysaito@opensource-robotics.tokyo.jp">Isaac I.Y. Saito</maintainer>
 
   <url>http://wiki.ros.org/laser_scan_matcher</url>
   <author>Ivan Dryanovski</author>


### PR DESCRIPTION
`laser_scan_matcher` (say LSM) depends on Andrea Censi's [CSM](http://censi.mit.edu/software/csm/) (as described in package.xml), whose source code is downloaded and built during LSM's build process. The commit version of CSM is hardcoded [here](https://github.com/ccny-ros-pkg/scan_tools/blob/ce5cdd199434eec2f277839506304b5a0d2c02da/laser_scan_matcher/csm/GetCSM.cmake#L20), which seems a bit outdated (I think [this is it](https://github.com/AndreaCensi/csm/commit/23703a998fff572503224eae026043e8c8048773) in 2010). CSM seems stable but there has been some newer commits since then.

This PR updates the commit version of CSM to be downloaded to the today's latest (since there seems to be no release tag in CSM I just assume the latest is stable).

We can wait for #28 to be merged; it's nicer that once travis is enabled we can test building on travis.
