### PR TITLE
Publish Poses with Covariance

### DIFF
--- a/laser_scan_matcher/CMakeLists.txt
+++ b/laser_scan_matcher/CMakeLists.txt
@@ -68,4 +68,5 @@ install(FILES laser_scan_matcher_nodelet.xml
 install(DIRECTORY demo
     DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION} )
 
-add_rostest(test/run.test) 
+add_rostest(test/run.test)
+add_rostest(test/covariance.test)

--- a/laser_scan_matcher/demo/demo.launch
+++ b/laser_scan_matcher/demo/demo.launch
@@ -1,35 +1,40 @@
-<!-- 
+<!--
 Example launch file: launches the scan matcher with pre-recorded data
 -->
 
 <launch>
   <arg name="IS_TWISTSTAMPED" default="true" />
   <arg name="use_rviz" default="true" />
+  <arg name="publish_covariance" default="false"/>
   #### set up data playback from bag #############################
 
   <param name="/use_sim_time" value="true"/>
   <param name="/stamped_vel" value="$(arg IS_TWISTSTAMPED)"/>
 
   <group if="$(arg use_rviz)">
-    <node pkg="rviz" type="rviz" name="rviz" 
+    <node pkg="rviz" type="rviz" name="rviz"
           args="-d $(find laser_scan_matcher)/demo/demo.rviz"/>
   </group>
 
-  <node pkg="rosbag" type="play" name="play" 
+  <node pkg="rosbag" type="play" name="play"
     args="$(find laser_scan_matcher)/demo/demo.bag --delay=5 --clock"/>
 
   #### publish an example base_link -> laser transform ###########
 
-  <node pkg="tf" type="static_transform_publisher" name="base_link_to_laser" 
+  <node pkg="tf" type="static_transform_publisher" name="base_link_to_laser"
     args="0.0 0.0 0.0 0.0 0.0 0.0 /base_link /laser 40" />
 
   #### start the laser scan_matcher ##############################
 
-  <node pkg="laser_scan_matcher" type="laser_scan_matcher_node" 
+  <group if="$(arg publish_covariance)">
+    <param name="laser_scan_matcher_node/do_compute_covariance" value="1"/>
+    <param name="laser_scan_matcher_node/publish_pose_with_covariance" value="true"/>
+    <param name="laser_scan_matcher_node/publish_pose_with_covariance_stamped" value="true"/>
+  </group>
+  <node pkg="laser_scan_matcher" type="laser_scan_matcher_node"
     name="laser_scan_matcher_node" output="screen">
 
     <param name="max_iterations" value="10"/>
-
   </node>
 
 </launch>

--- a/laser_scan_matcher/include/laser_scan_matcher/laser_scan_matcher.h
+++ b/laser_scan_matcher/include/laser_scan_matcher/laser_scan_matcher.h
@@ -43,6 +43,8 @@
 #include <sensor_msgs/LaserScan.h>
 #include <geometry_msgs/PoseStamped.h>
 #include <geometry_msgs/Pose2D.h>
+#include <geometry_msgs/PoseWithCovarianceStamped.h>
+#include <geometry_msgs/PoseWithCovariance.h>
 #include <geometry_msgs/TwistStamped.h>
 #include <nav_msgs/Odometry.h>
 #include <tf/transform_datatypes.h>
@@ -91,6 +93,8 @@ class LaserScanMatcher
 
     ros::Publisher  pose_publisher_;
     ros::Publisher  pose_stamped_publisher_;
+    ros::Publisher  pose_with_covariance_publisher_;
+    ros::Publisher  pose_with_covariance_stamped_publisher_;
 
     // **** parameters
 
@@ -101,7 +105,11 @@ class LaserScanMatcher
     double cloud_res_;
     bool publish_tf_;
     bool publish_pose_;
+    bool publish_pose_with_covariance_;
     bool publish_pose_stamped_;
+    bool publish_pose_with_covariance_stamped_;
+    std::vector<double> position_covariance_;
+    std::vector<double> orientation_covariance_;
 
     bool use_cloud_input_;
 

--- a/laser_scan_matcher/include/laser_scan_matcher/laser_scan_matcher.h
+++ b/laser_scan_matcher/include/laser_scan_matcher/laser_scan_matcher.h
@@ -136,7 +136,7 @@ class LaserScanMatcher
     bool received_imu_;
     bool received_odom_;
     bool received_vel_;
-    bool only_once_;
+    int n_times_;
 
     tf::Transform f2b_;    // fixed-to-base tf (pose of base frame in fixed frame)
     tf::Transform f2b_kf_; // pose of the last keyframe scan in fixed frame

--- a/laser_scan_matcher/include/laser_scan_matcher/laser_scan_matcher.h
+++ b/laser_scan_matcher/include/laser_scan_matcher/laser_scan_matcher.h
@@ -136,6 +136,7 @@ class LaserScanMatcher
     bool received_imu_;
     bool received_odom_;
     bool received_vel_;
+    bool only_once_;
 
     tf::Transform f2b_;    // fixed-to-base tf (pose of base frame in fixed frame)
     tf::Transform f2b_kf_; // pose of the last keyframe scan in fixed frame

--- a/laser_scan_matcher/include/laser_scan_matcher/laser_scan_matcher.h
+++ b/laser_scan_matcher/include/laser_scan_matcher/laser_scan_matcher.h
@@ -136,7 +136,6 @@ class LaserScanMatcher
     bool received_imu_;
     bool received_odom_;
     bool received_vel_;
-    int n_times_;
 
     tf::Transform f2b_;    // fixed-to-base tf (pose of base frame in fixed frame)
     tf::Transform f2b_kf_; // pose of the last keyframe scan in fixed frame

--- a/laser_scan_matcher/src/laser_scan_matcher.cpp
+++ b/laser_scan_matcher/src/laser_scan_matcher.cpp
@@ -49,7 +49,6 @@ LaserScanMatcher::LaserScanMatcher(ros::NodeHandle nh, ros::NodeHandle nh_privat
   received_imu_(false),
   received_odom_(false),
   received_vel_(false),
-  n_times_(10)
 {
   ROS_INFO("Starting LaserScanMatcher");
 
@@ -476,22 +475,22 @@ void LaserScanMatcher::processScan(LDP& curr_ldp_scan, const ros::Time& time)
 
   if (output_.valid)
   {
-    if (n_times_)
-    {
-      ROS_WARN("cov_x_m.size1: %zu  cov_x_m.size2: %zu  cov_x_m.tda: %zu",
-                output_.cov_x_m->size1,
-                output_.cov_x_m->size2,
-                output_.cov_x_m->tda);
-      ROS_WARN("cov_dx_dy1_m.size1: %zu  cov_dx_dy1_m.size2: %zu  cov_dx_dy1_m.tda: %zu",
-                output_.dx_dy1_m->size1,
-                output_.dx_dy1_m->size2,
-                output_.dx_dy1_m->tda);
-      ROS_WARN("cov_dx_dy2_m.size1: %zu  cov_dx_dy2_m.size2: %zu  cov_dx_dy2_m.tda: %zu",
-                output_.dx_dy2_m->size1,
-                output_.dx_dy2_m->size2,
-                output_.dx_dy2_m->tda);
-      n_times_--;
-    }
+    // Returns giant (uninitialized?) values
+    // ROS_WARN("cov_x_m.size1: %zu  cov_x_m.size2: %zu  cov_x_m.tda: %zu",
+    //           output_.cov_x_m->size1,
+    //           output_.cov_x_m->size2,
+    //           output_.cov_x_m->tda);
+    // Segfaults
+    // ROS_WARN_THROTTLE(1, "cov_x_m[0,0]: %f", gsl_matrix_get(output_.cov_x_m, 1, 1));
+    //// Segfaults
+    //ROS_WARN("cov_dx_dy1_m.size1: %zu  cov_dx_dy1_m.size2: %zu  cov_dx_dy1_m.tda: %zu",
+    //          output_.dx_dy1_m->size1,
+    //          output_.dx_dy1_m->size2,
+    //          output_.dx_dy1_m->tda);
+    //ROS_WARN("cov_dx_dy2_m.size1: %zu  cov_dx_dy2_m.size2: %zu  cov_dx_dy2_m.tda: %zu",
+    //          output_.dx_dy2_m->size1,
+    //          output_.dx_dy2_m->size2,
+    //          output_.dx_dy2_m->tda);
     // the correction of the laser's position, in the laser frame
     tf::Transform corr_ch_l;
     createTfFromXYTheta(output_.x[0], output_.x[1], output_.x[2], corr_ch_l);

--- a/laser_scan_matcher/src/laser_scan_matcher.cpp
+++ b/laser_scan_matcher/src/laser_scan_matcher.cpp
@@ -575,6 +575,15 @@ void LaserScanMatcher::processScan(LDP& curr_ldp_scan, const ros::Time& time)
 
       pose_with_covariance_stamped_publisher_.publish(pose_with_covariance_stamped_msg);
     }
+
+    // Free covariance gsl matrices to avoid leaking memory
+    if (input_.do_compute_covariance)
+    {
+      gsl_matrix_free(output_.cov_x_m);
+      gsl_matrix_free(output_.dx_dy1_m);
+      gsl_matrix_free(output_.dx_dy2_m);
+    }
+    
     if (publish_tf_)
     {
       tf::StampedTransform transform_msg (f2b_, time, fixed_frame_, base_frame_);

--- a/laser_scan_matcher/src/laser_scan_matcher.cpp
+++ b/laser_scan_matcher/src/laser_scan_matcher.cpp
@@ -478,21 +478,21 @@ void LaserScanMatcher::processScan(LDP& curr_ldp_scan, const ros::Time& time)
     if (input_.do_compute_covariance)
     {
       // Returns giant (uninitialized?) values
-      ROS_WARN_THROTTLE(1, "cov_x_m.size1: %zu  cov_x_m.size2: %zu  cov_x_m.tda: %zu",
+      ROS_INFO_THROTTLE(1, "cov_x_m.size1: %zu  cov_x_m.size2: %zu  cov_x_m.tda: %zu",
                 output_.cov_x_m->size1,
                 output_.cov_x_m->size2,
                 output_.cov_x_m->tda);
       // Segfaults
       // ROS_WARN_THROTTLE(1, "cov_x_m[0,0]: %f", gsl_matrix_get(output_.cov_x_m, 1, 1));
       //// Segfaults
-      //ROS_WARN("cov_dx_dy1_m.size1: %zu  cov_dx_dy1_m.size2: %zu  cov_dx_dy1_m.tda: %zu",
-      //          output_.dx_dy1_m->size1,
-      //          output_.dx_dy1_m->size2,
-      //          output_.dx_dy1_m->tda);
-      //ROS_WARN("cov_dx_dy2_m.size1: %zu  cov_dx_dy2_m.size2: %zu  cov_dx_dy2_m.tda: %zu",
-      //          output_.dx_dy2_m->size1,
-      //          output_.dx_dy2_m->size2,
-      //          output_.dx_dy2_m->tda);
+      ROS_INFO_THROTTLE(1, "cov_dx_dy1_m.size1: %zu  cov_dx_dy1_m.size2: %zu  cov_dx_dy1_m.tda: %zu",
+               output_.dx_dy1_m->size1,
+               output_.dx_dy1_m->size2,
+               output_.dx_dy1_m->tda);
+      ROS_INFO_THROTTLE(1, "cov_dx_dy2_m.size1: %zu  cov_dx_dy2_m.size2: %zu  cov_dx_dy2_m.tda: %zu",
+               output_.dx_dy2_m->size1,
+               output_.dx_dy2_m->size2,
+               output_.dx_dy2_m->tda);
     }
     else
     {

--- a/laser_scan_matcher/src/laser_scan_matcher.cpp
+++ b/laser_scan_matcher/src/laser_scan_matcher.cpp
@@ -48,7 +48,7 @@ LaserScanMatcher::LaserScanMatcher(ros::NodeHandle nh, ros::NodeHandle nh_privat
   initialized_(false),
   received_imu_(false),
   received_odom_(false),
-  received_vel_(false),
+  received_vel_(false)
 {
   ROS_INFO("Starting LaserScanMatcher");
 
@@ -475,22 +475,29 @@ void LaserScanMatcher::processScan(LDP& curr_ldp_scan, const ros::Time& time)
 
   if (output_.valid)
   {
-    // Returns giant (uninitialized?) values
-    // ROS_WARN("cov_x_m.size1: %zu  cov_x_m.size2: %zu  cov_x_m.tda: %zu",
-    //           output_.cov_x_m->size1,
-    //           output_.cov_x_m->size2,
-    //           output_.cov_x_m->tda);
-    // Segfaults
-    // ROS_WARN_THROTTLE(1, "cov_x_m[0,0]: %f", gsl_matrix_get(output_.cov_x_m, 1, 1));
-    //// Segfaults
-    //ROS_WARN("cov_dx_dy1_m.size1: %zu  cov_dx_dy1_m.size2: %zu  cov_dx_dy1_m.tda: %zu",
-    //          output_.dx_dy1_m->size1,
-    //          output_.dx_dy1_m->size2,
-    //          output_.dx_dy1_m->tda);
-    //ROS_WARN("cov_dx_dy2_m.size1: %zu  cov_dx_dy2_m.size2: %zu  cov_dx_dy2_m.tda: %zu",
-    //          output_.dx_dy2_m->size1,
-    //          output_.dx_dy2_m->size2,
-    //          output_.dx_dy2_m->tda);
+    if (input_.do_compute_covariance)
+    {
+      // Returns giant (uninitialized?) values
+      ROS_WARN_THROTTLE(1, "cov_x_m.size1: %zu  cov_x_m.size2: %zu  cov_x_m.tda: %zu",
+                output_.cov_x_m->size1,
+                output_.cov_x_m->size2,
+                output_.cov_x_m->tda);
+      // Segfaults
+      // ROS_WARN_THROTTLE(1, "cov_x_m[0,0]: %f", gsl_matrix_get(output_.cov_x_m, 1, 1));
+      //// Segfaults
+      //ROS_WARN("cov_dx_dy1_m.size1: %zu  cov_dx_dy1_m.size2: %zu  cov_dx_dy1_m.tda: %zu",
+      //          output_.dx_dy1_m->size1,
+      //          output_.dx_dy1_m->size2,
+      //          output_.dx_dy1_m->tda);
+      //ROS_WARN("cov_dx_dy2_m.size1: %zu  cov_dx_dy2_m.size2: %zu  cov_dx_dy2_m.tda: %zu",
+      //          output_.dx_dy2_m->size1,
+      //          output_.dx_dy2_m->size2,
+      //          output_.dx_dy2_m->tda);
+    }
+    else
+    {
+      ROS_WARN_THROTTLE(1, "not doing compute covariance");
+    }
     // the correction of the laser's position, in the laser frame
     tf::Transform corr_ch_l;
     createTfFromXYTheta(output_.x[0], output_.x[1], output_.x[2], corr_ch_l);

--- a/laser_scan_matcher/src/laser_scan_matcher.cpp
+++ b/laser_scan_matcher/src/laser_scan_matcher.cpp
@@ -49,7 +49,7 @@ LaserScanMatcher::LaserScanMatcher(ros::NodeHandle nh, ros::NodeHandle nh_privat
   received_imu_(false),
   received_odom_(false),
   received_vel_(false),
-  only_once_(true)
+  n_times_(10)
 {
   ROS_INFO("Starting LaserScanMatcher");
 
@@ -476,7 +476,7 @@ void LaserScanMatcher::processScan(LDP& curr_ldp_scan, const ros::Time& time)
 
   if (output_.valid)
   {
-    if (only_once_)
+    if (n_times_)
     {
       ROS_WARN("cov_x_m.size1: %zu  cov_x_m.size2: %zu  cov_x_m.tda: %zu",
                 output_.cov_x_m->size1,
@@ -490,7 +490,7 @@ void LaserScanMatcher::processScan(LDP& curr_ldp_scan, const ros::Time& time)
                 output_.dx_dy2_m->size1,
                 output_.dx_dy2_m->size2,
                 output_.dx_dy2_m->tda);
-      only_once_ = false;
+      n_times_--;
     }
     // the correction of the laser's position, in the laser frame
     tf::Transform corr_ch_l;

--- a/laser_scan_matcher/src/laser_scan_matcher.cpp
+++ b/laser_scan_matcher/src/laser_scan_matcher.cpp
@@ -196,7 +196,7 @@ void LaserScanMatcher::initParams()
   if (!nh_private_.getParam ("publish_pose_stamped", publish_pose_stamped_))
     publish_pose_stamped_ = false;
   if (!nh_private_.getParam ("publish_pose_with_covariance", publish_pose_with_covariance_))
-    publish_pose_with_covariance_ = true;
+    publish_pose_with_covariance_ = false;
   if (!nh_private_.getParam ("publish_pose_with_covariance_stamped", publish_pose_with_covariance_stamped_))
     publish_pose_with_covariance_stamped_ = false;
 

--- a/laser_scan_matcher/test/covariance.test
+++ b/laser_scan_matcher/test/covariance.test
@@ -1,0 +1,22 @@
+<launch>
+  <include file="$(find laser_scan_matcher)/demo/demo.launch">
+    <arg name="use_rviz" value="false" />  <!-- RViz/GUI is not needed for the tests -->
+    <arg name="publish_covariance" value="true" />
+  </include>
+
+  <!-- Check if PoseWithCovariance is publishing -->
+  <param name="test_cov/topic" value="/pose_with_covariance" />
+  <param name="test_cov/hz" value="10.0" />
+  <param name="test_cov/hzerror" value="1.0" />
+  <param name="test_cov/test_duration" value="15.0" />
+  <param name="test_cov/wait_time" value="15.0" />
+  <test pkg="rostest" type="hztest" test-name="test_cov" name="test_cov" time-limit="60"/>
+
+  <!-- Check if PoseWithCovarianceStamped is publishing -->
+  <param name="test_covstamped/topic" value="/pose_with_covariance_stamped" />
+  <param name="test_covstamped/hz" value="10.0" />
+  <param name="test_covstamped/hzerror" value="1.0" />
+  <param name="test_covstamped/test_duration" value="15.0" />
+  <param name="test_covstamped/wait_time" value="15.0" />
+  <test pkg="rostest" type="hztest" test-name="test_covstamped" name="test_covstamped" time-limit="60"/>
+</launch>


### PR DESCRIPTION
Addressing issue #43 by adding parameters to publish pose_with_covariance and pose_with_covariance_stamped messages.
- If no other parameters are set, the covariance array will default to 1e-9 across the diagonal.
- If the position_covariance or orientation_covariance parameters are set, those values will be used for the relevant fields.
- If the do_compute_covariance parameter is set, these messages will use CSM's covariance values for x, y, and yaw covariance, with 1e-9 or the parameterized covariance filling in the fields CSM does not calculate as appropriate
  Let me know if there are any concerns..
