### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/laser_ortho_projector/src/laser_ortho_projector_nodelet.cpp
+++ b/laser_ortho_projector/src/laser_ortho_projector_nodelet.cpp
@@ -31,8 +31,7 @@
 
 typedef scan_tools::LaserOrthoProjectorNodelet LaserOrthoProjectorNodelet;
 
-PLUGINLIB_DECLARE_CLASS (laser_ortho_projector, LaserOrthoProjectorNodelet,
-  LaserOrthoProjectorNodelet, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(LaserOrthoProjectorNodelet, nodelet::Nodelet)
 
 void LaserOrthoProjectorNodelet::onInit ()
 {

--- a/laser_scan_matcher/src/laser_scan_matcher_nodelet.cpp
+++ b/laser_scan_matcher/src/laser_scan_matcher_nodelet.cpp
@@ -39,8 +39,7 @@
 
 typedef scan_tools::LaserScanMatcherNodelet LaserScanMatcherNodelet;
 
-PLUGINLIB_DECLARE_CLASS(laser_scan_matcher, LaserScanMatcherNodelet,
-  LaserScanMatcherNodelet, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(LaserScanMatcherNodelet, nodelet::Nodelet)
 
 void LaserScanMatcherNodelet::onInit()
 {

--- a/laser_scan_sparsifier/src/laser_scan_sparsifier_nodelet.cpp
+++ b/laser_scan_sparsifier/src/laser_scan_sparsifier_nodelet.cpp
@@ -31,8 +31,7 @@
 
 typedef scan_tools::LaserScanSparsifierNodelet LaserScanSparsifierNodelet;
 
-PLUGINLIB_DECLARE_CLASS (laser_scan_sparsifier, LaserScanSparsifierNodelet, 
-  LaserScanSparsifierNodelet, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(LaserScanSparsifierNodelet, nodelet::Nodelet)
 
 void LaserScanSparsifierNodelet::onInit ()
 {

--- a/laser_scan_splitter/src/laser_scan_splitter_nodelet.cpp
+++ b/laser_scan_splitter/src/laser_scan_splitter_nodelet.cpp
@@ -31,8 +31,7 @@
 
 typedef scan_tools::LaserScanSplitterNodelet LaserScanSplitterNodelet;
 
-PLUGINLIB_DECLARE_CLASS (laser_scan_splitter, LaserScanSplitterNodelet, 
-  LaserScanSplitterNodelet, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(LaserScanSplitterNodelet, nodelet::Nodelet)
 
 void LaserScanSplitterNodelet::onInit ()
 {


### PR DESCRIPTION
These macros, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)

This change will allow the code to keep compiling on future ROS versions