### PR TITLE
[CI] Update travis config to fix errors with .rosinstall. Add ROS Lunar.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,13 +22,21 @@ env:
     - USE_DEB=true   ROS_DISTRO="kinetic"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - USE_DEB=true   ROS_DISTRO="kinetic"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
     - ROS_DISTRO="kinetic" PRERELEASE=true
+    - USE_DEB=true   ROS_DISTRO="lunar"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - USE_DEB=true   ROS_DISTRO="lunar"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - ROS_DISTRO="lunar" PRERELEASE=true
 matrix:
   allow_failures:
     - env: USE_DEB=false  ROS_DISTRO=indigo ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - env: ROS_DISTRO="indigo" PRERELEASE=true
+    - env: USE_DEB=true   ROS_DISTRO="jade"     ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - env: USE_DEB=true   ROS_DISTRO="jade"     ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
     - env: USE_DEB=false  ROS_DISTRO=jade   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - env: ROS_DISTRO="jade" PRERELEASE=true
     - env: ROS_DISTRO="kinetic" PRERELEASE=true
+    - env: USE_DEB=true   ROS_DISTRO="lunar"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - env: USE_DEB=true   ROS_DISTRO="lunar"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - env: ROS_DISTRO="lunar" PRERELEASE=true
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,10 @@ env:
   matrix:
     - USE_DEB=true   ROS_DISTRO="indigo"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - USE_DEB=true   ROS_DISTRO="indigo"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
-    - USE_DEB=false  ROS_DISTRO=indigo     ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu  UPSTREAM_WORKSPACE=file  $ROSINSTALL_FILENAME=".rosinstall"
     - ROS_DISTRO="indigo" PRERELEASE=true
     - USE_DEB=true   ROS_DISTRO="jade"     ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - USE_DEB=true   ROS_DISTRO="jade"     ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
     - ROS_DISTRO="jade" PRERELEASE=true
-    - USE_DEB=false  ROS_DISTRO=jade       ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu  UPSTREAM_WORKSPACE=file  $ROSINSTALL_FILENAME=".rosinstall"
     - USE_DEB=true   ROS_DISTRO="kinetic"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - USE_DEB=true   ROS_DISTRO="kinetic"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
     - ROS_DISTRO="kinetic" PRERELEASE=true


### PR DESCRIPTION
- Remove jobs that use .rosinstall. `ccny-ros-pkg/scan_tools/.rosinstall` contains scan_tools so duplicate package error occurs. It doesn't anything meaningful for CI purpose, so it should be fine to remove the CI jobs.
- Remove Jade that is EOL. Add Lunar. 