### PR TITLE
fix the coordinate transformation with odometry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ lib/
 docs/
 msg_gen/
 srv_gen/
+csm/
 *.*~
 __init__.py
 __init__.pyc

--- a/laser_scan_matcher/include/laser_scan_matcher/laser_scan_matcher.h
+++ b/laser_scan_matcher/include/laser_scan_matcher/laser_scan_matcher.h
@@ -90,6 +90,7 @@ class LaserScanMatcher
 
     tf::Transform base_to_laser_; // static, cached
     tf::Transform laser_to_base_; // static, cached, calculated from base_to_laser_
+    tf::Transform last_used_odom_tf_, latest_odom_tf_, odom_increment_tf_;
 
     ros::Publisher  pose_publisher_;
     ros::Publisher  pose_stamped_publisher_;
@@ -138,14 +139,13 @@ class LaserScanMatcher
     bool received_vel_;
 
     tf::Transform f2b_;    // fixed-to-base tf (pose of base frame in fixed frame)
-    tf::Transform f2b_kf_; // pose of the last keyframe scan in fixed frame
+    tf::Transform f2b_kf_; // pose of the base in fixed frame when last keyframe is taken
 
     ros::Time last_icp_time_;
 
     sensor_msgs::Imu latest_imu_msg_;
     sensor_msgs::Imu last_used_imu_msg_;
     nav_msgs::Odometry latest_odom_msg_;
-    nav_msgs::Odometry last_used_odom_msg_;
 
     geometry_msgs::Twist latest_vel_msg_;
 
@@ -179,8 +179,7 @@ class LaserScanMatcher
 
     bool newKeyframeNeeded(const tf::Transform& d);
 
-    void getPrediction(double& pr_ch_x, double& pr_ch_y,
-                       double& pr_ch_a, double dt);
+    void getPrediction(tf::Transform& inc_tf, double dt);
 
     void createTfFromXYTheta(double x, double y, double theta, tf::Transform& t);
 };


### PR DESCRIPTION
This is the same problem with request #55 
There are several issue in the use of coordinate system in the original pose. At #55 @siega-k tries to fix the issue. Generally, he's correct if you follow the comment on the code. I've came to the same conclusion at my [first attempt](https://imgur.com/zoGxt7E)

Despite the problem is much more complicated than I've thought, the solution is actually very simple and elegant. [Please see this visualization](https://imgur.com/v6jWFfK)
Explaination: The ICP matcher requires the scan from the keyframe and the current scan. It will output the pose of current scan in the keyframe scan, namely "corr_ch_l". So, if we have odometry, we would need to provide a prediction of the "corr_ch_l". Since "corr_ch_l" is attached to the laser_frame, we would need a vector pointing from the laser_frame@keyframe to laser_frame@now.

The original code mistakenly think tf1 * tf_something * tf1.inverse() would be the transformation of coordinate system, i.e. switch of basis. However, this actually accidentally gives the proper transition of the output "corr_ch_l". ( step3 of my [visualization](https://imgur.com/v6jWFfK) ). But is in fact incorrect.

P.s. All my calculation process is recorded [here](https://imgur.com/a/2wFUa)