### PR TITLE
Refactor and correct prediction code and transforms.

### DIFF
--- a/laser_scan_matcher/src/laser_scan_matcher.cpp
+++ b/laser_scan_matcher/src/laser_scan_matcher.cpp
@@ -778,7 +778,7 @@ bool LaserScanMatcher::getBaseLaserTransform(const std::string& frame_id)
     tf_listener_.waitForTransform(base_frame_, frame_id, ros::Time(0), ros::Duration(tf_timeout_));
     tf_listener_.lookupTransform (base_frame_, frame_id, ros::Time(0), base_from_laser);
   }
-  catch (tf::TransformException ex)
+  catch (const tf::TransformException& ex)
   {
     ROS_WARN("Could not get initial transform from base to laser frame, %s", ex.what());
     return false;
@@ -845,7 +845,7 @@ tf::Transform LaserScanMatcher::getPrediction(const ros::Time& stamp)
       tf_listener_.lookupTransform (base_frame_, last_icp_time_, base_frame_, stamp, fixed_frame_, pred_last_base_offset_tf);
       pred_last_base_offset = pred_last_base_offset_tf;
     }
-    catch (tf::TransformException ex)
+    catch (const tf::TransformException& ex)
     {
       ROS_WARN("Could not get base to fixed frame transform, %s", ex.what());
     }


### PR DESCRIPTION
The current code for taking in odom or velocity messages and generating predictions is incorrect.  I think this is likely the root cause of or has already been called out in several issues:
 - https://github.com/CCNYRoboticsLab/scan_tools/issues/20
 - https://github.com/CCNYRoboticsLab/scan_tools/pull/55
 - https://github.com/CCNYRoboticsLab/scan_tools/pull/58
 - https://github.com/CCNYRoboticsLab/scan_tools/issues/66

These types of prediction inputs are necessary when the environment is somewhat ambiguous, such as a hallway.

---

Here is an example of the scan matcher struggling to track the actual robot motion down a hallway:

**no predictions:**
[current w/o predictions (video)](https://user-images.githubusercontent.com/3259020/178891292-e837a491-8114-4cb6-839a-7cf1c0151e3d.mp4)

This case performs reasonably, but can't track down the long axis of the hallway when there aren't features nearby.

**velocity based predictions:**
[current w/ velocity predictions (video)](https://user-images.githubusercontent.com/3259020/178891467-7668e9cf-2850-4fd2-b910-883433dd2560.mp4)
:thinking: 

**odom based predictions:**
[current w/ odom predictions (video)](https://user-images.githubusercontent.com/3259020/178891676-d7827a3a-e586-4dfa-aa90-a3e8ea254548.mp4)

:thinking: 

---

Clearly something is wrong with the predictions. 

As has been pointed out in the other issues the code here is wrong:
https://github.com/CCNYRoboticsLab/scan_tools/blob/b5d9938/laser_scan_matcher/src/laser_scan_matcher.cpp#L456-L470
```
  getPrediction(pr_ch_x, pr_ch_y, pr_ch_a, dt);

  // the predicted change of the laser's position, in the fixed frame

  tf::Transform pr_ch;
  createTfFromXYTheta(pr_ch_x, pr_ch_y, pr_ch_a, pr_ch);

  // account for the change since the last kf, in the fixed frame

  pr_ch = pr_ch * (f2b_ * f2b_kf_.inverse());

  // the predicted change of the laser's position, in the laser frame

  tf::Transform pr_ch_l;
  pr_ch_l = laser_to_base_ * f2b_.inverse() * pr_ch * f2b_ * base_to_laser_ ;
```

The handling of the velocity message to create a prediction is also incorrect because the way the code is currently structured, the prediction is the differential in the fixed frame instead of the base_link frame, but the velocity will be in the base_link frame and isn't transformed into the fixed frame in any way.

Finally, the code is extra confusing because the variable names are either cryptic, or imply the opposite transform, or both.

---
This PR fixes all of that and also adds TF as an option for prediction input.  

The TF input works just like the odom  input, but uses tf instead of subscribing to an odom.  The TF transform if base link in the fixed frame would probably be provided by a kalman filter of various localization sensors, like [robot localization](http://docs.ros.org/en/noetic/api/robot_localization/html/index.html).  That way the kalman filter can deal with the various nuances of transforming data into the correct frame and fusing it together.

Results
---
**velocity based predictions:**
[fixed w/ velocity predictions (video)](https://user-images.githubusercontent.com/3259020/178893810-2b309992-a5fb-4efa-b19f-41fb15e7a60d.mp4)

**odom based predictions:**
[fixed w/ odom predictions (video)](https://user-images.githubusercontent.com/3259020/178893952-ce453b32-5687-4e33-af2f-2861ae529233.mp4)

@130s 
