### PR TITLE
Allow disabling tests with CATKIN_ENABLE_TESTING

### DIFF
--- a/laser_scan_matcher/CMakeLists.txt
+++ b/laser_scan_matcher/CMakeLists.txt
@@ -13,7 +13,7 @@ set( ROS_CXX_DEPENDENCIES
   nav_msgs)
 
 # Find catkin and all required ROS components
-find_package(catkin REQUIRED COMPONENTS ${ROS_CXX_DEPENDENCIES} rostest)
+find_package(catkin REQUIRED COMPONENTS ${ROS_CXX_DEPENDENCIES})
 find_package(PCL REQUIRED QUIET)
 
 # Find csm project
@@ -69,6 +69,7 @@ install(DIRECTORY demo
     DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION} )
 
 if(CATKIN_ENABLE_TESTING)
+  find_package(rostest)
   add_rostest(test/run.test)
   add_rostest(test/covariance.test)
 endif()

--- a/laser_scan_matcher/CMakeLists.txt
+++ b/laser_scan_matcher/CMakeLists.txt
@@ -68,5 +68,7 @@ install(FILES laser_scan_matcher_nodelet.xml
 install(DIRECTORY demo
     DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION} )
 
-add_rostest(test/run.test)
-add_rostest(test/covariance.test)
+if(CATKIN_ENABLE_TESTING)
+  add_rostest(test/run.test)
+  add_rostest(test/covariance.test)
+endif()


### PR DESCRIPTION
Most ROS packages now allow disabling test runs by setting `CATKIN_ENABLE_TESTING` to false. 

When I try to build `laser_scan_matcher` with `CATKIN_ENABLE_TESTING` set to false, I get this error:

```
CMake Error at /nix/store/y2dbjs0hpkdmra1jcnvih069nq27j9ka-ros-noetic-catkin-0.8.10-r1/share/catkin/cmake/test/tests.cmake:18 (message):
  () is not available when tests are not enabled.  The CMake code should only
  use it inside a conditional block which checks that testing is enabled:

  if(CATKIN_ENABLE_TESTING)

    (...)

  endif()

Call Stack (most recent call first):
  CMakeLists.txt:71 (add_rostest)
```

This PR just uses the recommended method to disable tests when the user requests it.